### PR TITLE
Add information about rule totals to style summaries

### DIFF
--- a/scripts/style_stats.py
+++ b/scripts/style_stats.py
@@ -67,7 +67,7 @@ def summarize_tts(df):
     total_tts = pd.DataFrame()
     try:
         total_tts = repo_grps.apply(lambda x: x[(x['tone_tags'] != 'tagged') & (x[
-                'tone_tags'] != 'untagged')]['tone_tags'].count()).reset_index(name='count')
+            'tone_tags'] != 'untagged')]['tone_tags'].count()).reset_index(name='count')
         total_tts["tone_tags"] = "total"
     except TypeError:
         print("TypeError: DataFrame.reset_index() got an unexpected keyword argument 'name'")

--- a/scripts/style_stats.py
+++ b/scripts/style_stats.py
@@ -60,7 +60,7 @@ def compare_dfs(df_to, df_from):
     return "\n".join([f"{key},{value}" for key, value in coll_to.items()])
 
 
-def summarize_tts(df):
+def summarize_tts(df, logger):
     repo_grps = df.groupby(by='repo')
     summary = repo_grps['tone_tags'].value_counts().reset_index(name='count')
 
@@ -69,7 +69,7 @@ def summarize_tts(df):
             'tone_tags'] != 'untagged')]['tone_tags'].count()).reset_index(name='count')
         total_tts["tone_tags"] = "total"
     except TypeError as e:
-        print(e)
+        logger.warning(e.__str__() + "\n*total* is set to 0 for all repos")
         total_tts = pd.DataFrame([['os', 'total', 0], ['premium', 'total', 0]], columns=['repo', 'tone_tags', 'count'])
 
     unique_rules = repo_grps['id'].nunique().to_frame().reset_index()
@@ -100,7 +100,7 @@ def __main__():
         all_rows_to.extend(rows_to)
         df_to = DataFrame(rows_to, columns=headers)
         df_from = DataFrame(rows_from, columns=headers)
-        locale_summary = summarize_tts(df_to)
+        locale_summary = summarize_tts(df_to, logger)
 
         logger.debug(locale_summary)
         open(summary_filepath, 'w').write(locale_summary.to_string(index=False))
@@ -110,7 +110,7 @@ def __main__():
 
     df_all_to = DataFrame(all_rows_to, columns=headers)
 
-    all_summary = summarize_tts(df_all_to)
+    all_summary = summarize_tts(df_all_to, logger)
     all_filepath = os.path.join(cli.args.out_dir, 'all_time_summary.txt')
     open(all_filepath, 'w').write(all_summary.to_string(index=False))
 

--- a/scripts/style_stats.py
+++ b/scripts/style_stats.py
@@ -97,7 +97,7 @@ def __main__():
         test_filepath = os.path.join(locale_dir, 'test_summary.txt')
         test_summary = pd.concat([summary, unique_rules], axis=0).sort_values('repo')
         test_summary.groupby(by='repo')
-        #the default index still needs to be dropped, maybe switching to *to_csv*? (has index=False)
+        # the default index still needs to be dropped, maybe switching to *to_csv*? (has index=False)
         open(test_filepath, 'w').write(test_summary.to_string())
 
 

--- a/scripts/style_stats.py
+++ b/scripts/style_stats.py
@@ -64,13 +64,13 @@ def summarize_tts(df):
     repo_grps = df.groupby(by='repo')
     summary = repo_grps['tone_tags'].value_counts().reset_index(name='count')
 
-    total_tts = pd.DataFrame()
     try:
         total_tts = repo_grps.apply(lambda x: x[(x['tone_tags'] != 'tagged') & (x[
             'tone_tags'] != 'untagged')]['tone_tags'].count()).reset_index(name='count')
         total_tts["tone_tags"] = "total"
-    except TypeError:
-        print("TypeError: DataFrame.reset_index() got an unexpected keyword argument 'name'")
+    except TypeError as e:
+        print(e)
+        total_tts = pd.DataFrame([['os', 'total', 0], ['premium', 'total', 0]], columns=['repo', 'tone_tags', 'count'])
 
     unique_rules = repo_grps['id'].nunique().to_frame().reset_index()
     unique_rules = unique_rules.rename(columns={'id': 'count'})


### PR DESCRIPTION
Closes #16 , closes #17 

- add number of unique rules (unique_rules)
- add sum of tone tags assigned to rules (total)
- add all_time_summary over all languages: sum of all tone-tagged rules for all locales (French `professional` + Dutch `professional`, …)