### PR TITLE
Skip entity resolution when parsing XML files

### DIFF
--- a/scripts/lib/rule_file.py
+++ b/scripts/lib/rule_file.py
@@ -1,9 +1,13 @@
 from os import path
 from lxml import etree
 from elements import Rule, RuleGroup, Category
+import re
 
 
 class RuleFile:
+    # Used to remove entities from XML strings, as they're not needed
+    entity_pattern = r"&\w+;"
+
     # Constructor takes as param only filepath, and derives from it a parsed XML tree
     # and a list of Rule instances.
     def __init__(self, filepath: str, rules_path: str):
@@ -13,7 +17,15 @@ class RuleFile:
 
     # Parse XML from path, return parsed element tree.
     def parse_xml(self):
-        return etree.parse(self.filepath)
+        # No need to resolve them or load external files.
+        parser = etree.XMLParser(load_dtd=False, resolve_entities=False)
+        return etree.fromstring(self.xml_string, parser=parser)
+
+    # Clean up XML string from filepath; namely, we just need to remove entities as those can't be resolved properly,
+    # and they'd just slow everything down anyway.
+    @property
+    def xml_string(self):
+        return re.sub(self.entity_pattern, 'REPLACED_ENTITY', open(self.filepath).read()).encode('utf-8')
 
     @property
     def name(self):

--- a/tests/mock/loose_xml/good.xml
+++ b/tests/mock/loose_xml/good.xml
@@ -2,7 +2,11 @@
 <?xml-stylesheet type="text/xsl" href="../print.xsl" title="Pretty print" ?>
 <?xml-stylesheet type="text/css" href="../rules.css" title="Easy editing stylesheet" ?>
 
-<rules lang="pt-BR" xsi:noNamespaceSchemaLocation="../../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<!DOCTYPE rules [
+  <!ENTITY msg_intro "message intro foo">
+]>
+
+<rules lang="pt-BR" xsi:noNamespaceSchemaLocation="../schemata/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <category id="BR_SPELLING" name="ortografia brasileira" type="misspelling">
     <rule id='PARONYM_PREMIO_252_PT' name='Parónimo: premio'>
       <pattern>
@@ -10,7 +14,7 @@
         <token min='0' postag='A.+' postag_regexp='yes'/>
         <token regexp='yes'>premios?</token>
       </pattern>
-      <message>Esta palavra é um verbo. Se pretende referir-se a um nome ou adjetivo, deve utilizar a forma acentuada.</message>
+      <message>&msg_intro;, esta palavra é um verbo. Se pretende referir-se a um nome ou adjetivo, deve utilizar a forma acentuada.</message>
       <suggestion><match no='1' include_skipped='all'/> <match no='2' include_skipped='all'/> prêmio<match no='3' regexp_match='.+?(s?)$' regexp_replace='$1'/></suggestion>
       <url>https://pt.wiktionary.org/wiki/prémio</url>
       <example correction='no prêmio'><marker>no premio</marker>.</example>

--- a/tests/mock/loose_xml/good_groups.xml
+++ b/tests/mock/loose_xml/good_groups.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="../print.xsl" title="Pretty print" ?>
 <?xml-stylesheet type="text/css" href="../rules.css" title="Easy editing stylesheet" ?>
 
-<rules lang="pt-BR" xsi:noNamespaceSchemaLocation="../../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<rules lang="pt-BR" xsi:noNamespaceSchemaLocation="../schemata/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <category id="BR_SPELLING" name="ortografia brasileira" type="misspelling">
     <rulegroup id="foo" name="bar">
       <rule>

--- a/tests/mock/schemata/pattern.xsd
+++ b/tests/mock/schemata/pattern.xsd
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<!-- 
+ * LanguageTool, a natural language style checker 
+ * Copyright (c) Marcin Miłkowski, 2014 (http://www.languagetool.org)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ 
+ Schema for patterns: used in grammar rules and in disambiguator rules
+ -->
+ 
+ 	<xs:annotation>
+		<xs:documentation xml:lang="en"> Unification declarations
+		</xs:documentation>
+	</xs:annotation>
+
+	<xs:element name="unification">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="equivalence" minOccurs="1" maxOccurs="unbounded" />
+			</xs:sequence>
+			<xs:attribute name="feature" type="xs:ID" use="required" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:element name="equivalence">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="token"/>
+			</xs:sequence>
+			<xs:attribute name="type" type="xs:ID" use="required" />
+		</xs:complexType>
+	</xs:element>
+
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Phrase-related vocabulary</xs:documentation>
+	</xs:annotation>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Phrase definitions</xs:documentation>
+	</xs:annotation>
+	<xs:element name="phrases">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="phrase" minOccurs="1" maxOccurs="unbounded" />
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">individual phrase definition</xs:documentation>
+	</xs:annotation>
+	<xs:element name="phrase">
+		<xs:complexType>
+			<xs:choice minOccurs="1" maxOccurs="unbounded">
+				<xs:element ref="unify" />
+				<xs:element ref="and" />
+				<xs:element ref="token" />
+				<xs:element ref="includephrases" />
+			</xs:choice>
+			<xs:attribute name="id" type="xs:ID" use="required" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:element name="includephrases">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="phraseref" minOccurs='1' maxOccurs='unbounded' />
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">element that points to the defined phrase </xs:documentation>
+	</xs:annotation>
+	<xs:element name="phraseref">
+		<xs:complexType>
+			<xs:attribute name="idref" type="xs:IDREF" use="required" />
+		</xs:complexType>
+	</xs:element>
+ 
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Reference to the pattern's token element.
+		Might be used in a suggestion or in the pattern.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="match">
+	<xs:complexType mixed="true">
+		<xs:attribute name="no" type="xs:nonNegativeInteger" use="required" />
+		<xs:attribute name="regexp_match" type="xs:string" use="optional" />
+		<xs:attribute name="regexp_replace" type="xs:string" use="optional" />
+		<xs:attribute name="postag_regexp" type="binaryYesNo" use="optional" default="no" />
+		<xs:attribute name="postag" type="xs:string" use="optional" />
+		<xs:attribute name="postag_replace" type="xs:string" use="optional" />
+		<xs:attribute name="setpos" type="binaryYesNo" use="optional" default="no" />
+		<xs:attribute name="case_conversion" use="optional">
+			<xs:simpleType>
+				<xs:restriction base="xs:NMTOKEN">
+					<xs:enumeration value="startlower" />
+					<xs:enumeration value="startupper" />
+					<xs:enumeration value="allupper" />
+					<xs:enumeration value="alllower" />
+					<xs:enumeration value="preserve" />
+					<xs:enumeration value="firstupper" />
+					<xs:enumeration value="notashkeel" />
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="include_skipped" type="includeSelector" use="optional" default="none" />
+	</xs:complexType>
+	</xs:element>
+
+	<xs:element name="token">
+	<xs:complexType mixed="true">
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="exception" />
+				<xs:element ref="match" />
+			</xs:choice>
+			<xs:attribute name="postag_regexp" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="inflected" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="negate" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="regexp" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="chunk" use="optional">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<!--
+						For English, the Penn treebank has been used to train the OpenNLP models we use internally:
+						http://bulba.sdsu.edu/jeanette/thesis/PennTags.html#Phrase
+						The first character is used to fit these phrases to our token-based system:
+						B = beginning of phrase, I = inside phrase, E = end of phrase (only for noun phrases)
+						Feel free to add others provided by OpenNLP if you need them.
+						-->
+						<!-- start of noun phrases: -->
+						<xs:enumeration value="B-NP-singular" />
+						<xs:enumeration value="B-NP-plural" />
+						<!-- inside noun phrases: -->
+						<xs:enumeration value="I-NP-singular" />
+						<xs:enumeration value="I-NP-plural" />
+						<!-- end of noun phrases: -->
+						<xs:enumeration value="E-NP-singular" />
+						<xs:enumeration value="E-NP-plural" />
+						<!-- verb phrases: -->
+						<xs:enumeration value="B-VP" />
+						<xs:enumeration value="I-VP" />
+						<!-- prepositional phrases: -->
+						<xs:enumeration value="B-PP" />
+						<xs:enumeration value="I-PP" />
+						<!-- particle -->
+						<xs:enumeration value="B-PRT" />
+						<!-- adjective phrases: -->
+						<xs:enumeration value="B-ADJP" />
+						<xs:enumeration value="I-ADJP" />
+						<!-- adverb phrases: -->
+						<xs:enumeration value="B-ADVP" />
+						<xs:enumeration value="I-ADVP" />
+                                                <!-- adverbial participle phrases (for Russian): -->
+						<xs:enumeration value="B-DPT" />
+						<xs:enumeration value="I-DPT" />
+						<!-- other: -->
+						<xs:enumeration value="B-LST" />
+						<xs:enumeration value="B-SBAR" />
+                                                <xs:enumeration value="O" />
+					    <!-- Dealing with typewriter/typographic apostrophe (used in French) -->
+					    <xs:enumeration value="containsTypewriterApostrophe" />
+					    <xs:enumeration value="containsTypographicApostrophe" />
+						<!-- Romance languages -->
+					    <xs:enumeration value="GV" />
+					    <xs:enumeration value="PTime" />
+						<!--MayMissingYo (used in Russian) -->
+						<xs:enumeration value="MayMissingYO" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="chunk_re" type="xs:token" use="optional" />
+			<xs:attribute name="spacebefore" use="optional" default="ignore">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="yes" />
+						<xs:enumeration value="no" />
+						<xs:enumeration value="ignore" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="postag" type="xs:token" use="optional" />
+			<xs:attribute name="skip" use="optional">
+				<xs:simpleType>
+					<xs:restriction base="xs:integer">
+						<xs:minInclusive value="-1" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="min" use="optional">
+				<xs:simpleType>
+					<xs:restriction base="xs:integer">
+						<xs:minInclusive value="0" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="max" use="optional">
+				<xs:simpleType>
+					<xs:restriction base="xs:integer">
+						<xs:minInclusive value="-1" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="negate_pos" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="case_sensitive" type="binaryYesNo" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Enables logical AND between token elements.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="and">
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="token" minOccurs="2" maxOccurs="unbounded" />
+				<xs:element ref="marker" minOccurs="0" maxOccurs="1" />
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+	
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Enables logical OR between token elements.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="or">
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="token" minOccurs="2" maxOccurs="unbounded" />
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Exception to the matched token.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="exception">
+		<xs:complexType mixed="true">			
+			<xs:attribute name="postag_regexp" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="negate_pos" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="postag" type="xs:string" use="optional" />
+			<xs:attribute name="spacebefore" use="optional" default="ignore">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="yes" />
+						<xs:enumeration value="no" />
+						<xs:enumeration value="ignore" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="inflected" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="scope" use="optional" default="current">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="current" />
+						<xs:enumeration value="next" />
+						<xs:enumeration value="previous" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="regexp" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="negate" type="binaryYesNo" use="optional" default="no" />
+			<xs:attribute name="case_sensitive" type="binaryYesNo" use="optional" />
+		</xs:complexType>
+	</xs:element>
+ 
+ 	<xs:element name="unify">
+		<xs:complexType>
+			<xs:sequence minOccurs="1" maxOccurs="unbounded">
+				<xs:element ref="feature"/>
+				<xs:choice minOccurs="0" maxOccurs="unbounded">
+					<xs:element ref="and" />
+					<xs:element ref="marker" minOccurs="0" maxOccurs="1"/>
+					<xs:element ref="token" />
+					<xs:element ref="unify-ignore" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+			</xs:sequence>
+			<xs:attribute name="negate" type="binaryYesNo" use="optional" default="no" />
+		</xs:complexType>
+	</xs:element>
+	
+	<xs:element name="feature">
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="type" />
+			</xs:choice>
+			<xs:attribute name="id" type="xs:IDREF" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	
+	<xs:element name="type">
+		<xs:complexType>
+			<xs:attribute name="id" type="xs:IDREF"/>
+		</xs:complexType>
+	</xs:element>
+ 
+ 
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Helper type for binary choices.</xs:documentation>
+	</xs:annotation>
+	<xs:simpleType name="binaryYesNo">
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="yes" />
+			<xs:enumeration value="no" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Helper type for match[@include_skipped].</xs:documentation>
+	</xs:annotation>
+	<xs:simpleType name="includeSelector">
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="none" />
+			<xs:enumeration value="all" />
+			<xs:enumeration value="following" />
+		</xs:restriction>
+	</xs:simpleType>
+ 
+ 	<xs:annotation>
+		<xs:documentation xml:lang="en">Marks the matched part of the example.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="marker">
+		<xs:complexType mixed="false">
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="or" />
+				<xs:element ref="token" />
+				<xs:element ref="unify" />
+				<xs:element ref="and" />
+				<xs:element ref="phraseref" />
+				<xs:element ref="unify-ignore" />
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Marks the neutral part of the unified sequence.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="unify-ignore">
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="and" />
+				<xs:element ref="marker" minOccurs="0" maxOccurs="1"/>
+				<xs:element ref="token" />
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+
+</xs:schema>

--- a/tests/mock/schemata/rules.xsd
+++ b/tests/mock/schemata/rules.xsd
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<!-- 
+ * LanguageTool, a natural language style checker 
+ * Copyright (c) Marcin Miłkowski, 2014 (http://www.languagetool.org)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ 
+ Schema for rule files
+ -->
+
+	<xs:include schemaLocation="pattern.xsd"/>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Main element</xs:documentation>
+	</xs:annotation>
+
+	<xs:element name="rules">
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded" >
+				<xs:element ref="unification" />
+				<xs:element ref="phrases"/>
+				<xs:element ref="category"/>
+			</xs:choice>
+			<xs:attribute name="lang" type="xs:language" use="required" />
+			<xs:attribute name="idprefix" type="xs:string" />
+			<xs:attribute name="premium" type="binaryYesNo" default="no"/>
+			<xs:attribute name="integrate">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="replace"/>
+						<xs:enumeration value="add"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Use the category element to group rules/rulegroups.</xs:documentation>
+		<xs:documentation xml:lang="en">The attribute name shows the category use, e.g. 'Grammar', 'Spelling', 'Style' etc.</xs:documentation>
+	</xs:annotation>
+
+	<xs:element name="category">
+		<xs:complexType>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="rule" />
+				<xs:element ref="rulegroup" />
+			</xs:choice>
+			<xs:attribute name="default">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="off" />
+						<xs:enumeration value="on" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute ref="name" use="required" />
+			<xs:attribute name="id" type="xs:ID" use="required" />
+			<xs:attribute name="premium" type="binaryYesNo"/>
+			<xs:attribute ref="type" />
+			<xs:attribute name="external" type="binaryYesNo" />
+			<xs:attribute name="tab" />
+			<xs:attribute name="tags">
+		        <xs:simpleType>
+		            <xs:list>
+		                <xs:simpleType>
+		                    <xs:restriction base="xs:NMTOKEN">
+		                        <xs:enumeration value="default" />
+		                        <xs:enumeration value="picky" />
+		                        <xs:enumeration value="academic" />
+		                        <xs:enumeration value="clarity" />
+		                        <xs:enumeration value="professional" />
+		                        <xs:enumeration value="creative" />
+								<xs:enumeration value="customer" />
+								<xs:enumeration value="jobapp" />
+								<xs:enumeration value="objective" />
+								<xs:enumeration value="elegant" />
+		                    </xs:restriction>
+		                </xs:simpleType>
+		            </xs:list>
+		        </xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="tone_tags" type="xs:string"/>
+			<xs:attribute name="is_goal_specific" type="xs:boolean"/>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en"> Defines a group of rules
+			to display several rules as one in the configuration user interface. A group has a unique ID.
+			The whole rule group can be switched by default off using the attribute 'default'.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="rulegroup">
+		<xs:complexType>
+			<xs:sequence minOccurs="1">
+				<xs:element ref="url" minOccurs="0" maxOccurs="1" />
+				<xs:element ref="short" minOccurs="0" maxOccurs="1" />
+				<xs:element ref="antipattern" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="rule" maxOccurs="unbounded" />
+			</xs:sequence>
+			<xs:attribute name="default">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="off" />
+						<xs:enumeration value="temp_off" />
+						<xs:enumeration value="on" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute ref="name" use="required" />
+			<xs:attribute name="premium" type="binaryYesNo"/>
+			<xs:attribute name="id" type="xs:ID" use="required" />
+			<xs:attribute ref="type" />
+			<xs:attribute name="tags" >
+			    <xs:simpleType>
+			        <xs:list>
+			            <xs:simpleType>
+			                <xs:restriction base="xs:NMTOKEN">
+			                    <xs:enumeration value="default" />
+			                    <xs:enumeration value="picky" />
+			                    <xs:enumeration value="academic" />
+			                    <xs:enumeration value="clarity" />
+			                    <xs:enumeration value="professional" />
+			                    <xs:enumeration value="creative" />
+								<xs:enumeration value="customer" />
+								<xs:enumeration value="jobapp" />
+								<xs:enumeration value="objective" />
+								<xs:enumeration value="elegant" />
+			                </xs:restriction>
+			            </xs:simpleType>
+			        </xs:list>
+			    </xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="tone_tags" type="xs:string"/>
+			<xs:attribute name="is_goal_specific" type="xs:boolean"/>
+		    <xs:attribute name="min_prev_matches" use="optional">
+		        <xs:simpleType>
+		            <xs:restriction base="xs:integer">
+		                <xs:minInclusive value="1" />
+		            </xs:restriction>
+		        </xs:simpleType>
+		    </xs:attribute>
+		    <xs:attribute name="distance_tokens" use="optional">
+		        <xs:simpleType>
+		            <xs:restriction base="xs:integer">
+		                <xs:minInclusive value="1" />
+		            </xs:restriction>
+		        </xs:simpleType>
+		    </xs:attribute>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:attribute name="type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
+				Localization Quality Issue Type, according to Internationalization Tag Set (ITS) Version 2.0,
+				see http://www.w3.org/International/multilingualweb/lt/drafts/its20/its20.html#lqissue-typevalues
+				(added in LanguageTool 2.0)
+			</xs:documentation>
+		</xs:annotation>
+		<xs:simpleType>
+			<xs:restriction base="xs:NMTOKEN">
+				<xs:enumeration value="terminology" />
+				<xs:enumeration value="mistranslation" />
+				<xs:enumeration value="omission" />
+				<xs:enumeration value="untranslated" />
+				<xs:enumeration value="addition" />
+				<xs:enumeration value="duplication" />
+				<xs:enumeration value="inconsistency" />
+				<xs:enumeration value="grammar" />
+				<xs:enumeration value="legal" />
+				<xs:enumeration value="register" />
+				<xs:enumeration value="locale-specific-content" />
+				<xs:enumeration value="locale-violation" />
+				<xs:enumeration value="style" />
+				<xs:enumeration value="characters" />
+				<xs:enumeration value="misspelling" />
+				<xs:enumeration value="typographical" />
+				<xs:enumeration value="formatting" />
+				<xs:enumeration value="inconsistent-entities" />
+				<xs:enumeration value="numbers" />
+				<xs:enumeration value="markup" />
+				<xs:enumeration value="pattern-problem" />
+				<xs:enumeration value="whitespace" />
+				<xs:enumeration value="internationalization" />
+				<xs:enumeration value="length" />
+				<xs:enumeration value="non-conformance" />
+				<xs:enumeration value="uncategorized" />
+				<xs:enumeration value="other" />
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:attribute>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en"> The rule element. The
+			unique ID is required only if the rule is not contained in a rule group.
+			The rule can be switched by default off (using the default attribute).
+		</xs:documentation>
+	</xs:annotation>
+	<xs:element name="rule">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="antipattern" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:choice>
+					<xs:element ref="pattern" />
+					<xs:element ref="regexp" />
+				</xs:choice>
+				<xs:element ref="filter" minOccurs="0" maxOccurs="1" />
+				<xs:element ref="message" />
+				<xs:element ref="suggestion" minOccurs="0" maxOccurs="15" />
+				<xs:element ref="url" minOccurs="0" maxOccurs="1" />
+				<xs:element ref="short" minOccurs="0" />
+				<xs:element ref="example" minOccurs="1" maxOccurs="unbounded" />
+			</xs:sequence>
+			<xs:attribute name="default">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="off" />
+						<xs:enumeration value="temp_off" />
+						<xs:enumeration value="on" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="premium" type="binaryYesNo"/>
+			<xs:attribute name="name" type="xs:string" />
+			<xs:attribute name="id" type="xs:ID" />
+			<xs:attribute ref="type" />
+			<xs:attribute name="tags" />
+			<xs:attribute name="tone_tags" type="xs:string"/>
+			<xs:attribute name="is_goal_specific" type="xs:boolean"/>
+		    <xs:attribute name="min_prev_matches" use="optional">
+		        <xs:simpleType>
+		            <xs:restriction base="xs:integer">
+		                <xs:minInclusive value="1" />
+		            </xs:restriction>
+		        </xs:simpleType>
+		    </xs:attribute>
+		    <xs:attribute name="distance_tokens" use="optional">
+		        <xs:simpleType>
+		            <xs:restriction base="xs:integer">
+		                <xs:minInclusive value="1" />
+		            </xs:restriction>
+		        </xs:simpleType>
+		    </xs:attribute>
+		</xs:complexType>
+	</xs:element>
+
+ 	<xs:element name="pattern">
+		<xs:complexType>
+			<xs:choice minOccurs="1" maxOccurs="unbounded">
+				<xs:element ref="token" />
+				<xs:element ref="phraseref" />
+				<xs:element ref="and" />
+				<xs:element ref="or" />
+				<xs:element ref="unify" />
+				<xs:element ref="marker" maxOccurs="1"/>
+			</xs:choice>
+			<xs:attribute name="case_sensitive" type="binaryYesNo" />
+			<xs:attribute name="raw_pos" type="binaryYesNo" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:element name="regexp">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="case_sensitive" type="binaryYesNo"/>
+					<xs:attribute name="type" default="smart">
+						<xs:simpleType>
+							<xs:restriction base="xs:NMTOKEN">
+								<xs:enumeration value="smart" />
+								<xs:enumeration value="exact" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="mark">
+						<xs:simpleType>
+							<xs:restriction base="xs:integer">
+								<xs:minInclusive value="1" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">A negative-matching pattern used to
+			mark up complex exceptions in rules. Note: it does not support
+			phrases and OR operations for simplicity.
+		</xs:documentation>
+	</xs:annotation>
+	<xs:element name="antipattern">
+		<xs:complexType>
+			<xs:choice minOccurs="1" maxOccurs="unbounded">
+				<xs:element ref="token" />
+				<xs:element ref="and" />
+				<xs:element ref="unify" />
+				<xs:element ref="marker" />
+				<xs:element ref="example" minOccurs="0" maxOccurs="unbounded" /><!-- we don't require that, but this element should appear at the end -->
+			</xs:choice>
+			<xs:attribute name="case_sensitive" type="binaryYesNo" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">A short description of
+			the error detected by this rule displayed on the
+			context menu in LibreOffice/OpenOffice.org.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="short" type="xs:token" />
+
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Message shown to the user if a rule matches.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="message" xml:space="preserve">
+		<xs:complexType mixed="true">
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="suggestion" />
+				<xs:element ref="match" />
+			</xs:choice>
+			<xs:attribute name="suppress_misspelled" type="binaryYesNo"/>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:element name="filter">
+		<xs:complexType>
+			<xs:attribute name="class" type="xs:string" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">A fully qualified Java class that extends the RuleFilter class</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="args" type="xs:string" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Arguments given to the Java code: a space-separated list with 
+						elements in the form of 'key:\x', where key is the parameter name and x is a number
+						that refers to the pattern's token. Number and parameter names depend on the Java code.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+			<xs:documentation xml:lang="en">URL with further information
+				about the linguistic rule behind this error.</xs:documentation>
+  	</xs:annotation>
+	<xs:element name="url" type="xs:anyURI" />
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Suggestion displayed to the user.</xs:documentation>
+	</xs:annotation>
+	<xs:element name="suggestion">
+		<xs:complexType mixed="true">
+			<xs:sequence minOccurs='0' maxOccurs='unbounded'>
+				<xs:element ref="match" />
+			</xs:sequence>
+			<xs:attribute name="suppress_misspelled" type="binaryYesNo"/>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:annotation>
+		<xs:documentation xml:lang="en">Specifies examples used
+			in JUnit tests and as documentation.
+			The attribute 'correction' is used to check if the suggested correction
+			is correct; multiple suggestions are joined with "|".
+			The attribute triggers_error is not used by the software.
+		</xs:documentation>
+	</xs:annotation>
+
+	<xs:element name="example" xml:space="preserve">
+	<xs:complexType mixed="true">
+	  <xs:choice minOccurs="0" maxOccurs="unbounded">
+		<xs:element name="marker" >
+			<xs:complexType>
+				<xs:simpleContent>
+					<xs:extension base="xs:string"/>
+				</xs:simpleContent>
+			</xs:complexType>
+		</xs:element>
+	  </xs:choice>
+	  <xs:attribute name="correction" type="xs:string" />
+		<xs:attribute name="type">
+		<xs:simpleType>
+		  <xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="correct" />
+			<xs:enumeration value="incorrect" />
+			<xs:enumeration value="triggers_error" />
+		  </xs:restriction>
+		</xs:simpleType>
+		</xs:attribute>
+	<xs:attribute name="reason" type="xs:string" />
+	</xs:complexType>
+  </xs:element>
+
+	<xs:attribute name="name">
+		<xs:simpleType>
+			<xs:restriction base="xs:string">
+				<xs:minLength value="1"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:attribute>
+
+</xs:schema>


### PR DESCRIPTION
 - we don't need those, we're just counting rules;

 - the parser doesn't resolve them, but it still needs the entities to be defined (which is good);

 - to counter that, we also edit the XML string, replacing all entities with a placeholder.